### PR TITLE
Feature/loader

### DIFF
--- a/src/components/Category.js
+++ b/src/components/Category.js
@@ -9,6 +9,8 @@ import { db } from "constant/firebase"
 import { SPREADSHEET_KEY } from "constant/static"
 // context
 import { StateContext } from "context/StateContext"
+// components
+import Loader from "components/Loader"
 
 const COLUMNS = [
   {
@@ -38,10 +40,9 @@ const COLUMNS = [
   },
 ]
 
-// Fetches data for the category and displays in the antd table
-const Category = () => {
+const CategoryComponent = ({ stateContext }) => {
   let { category } = useParams()
-  const { selectedState } = useContext(StateContext)
+  const { selectedState } = stateContext
 
   // fetch all by default
   let refToUse = db.ref(`${SPREADSHEET_KEY}/${category}`)
@@ -75,6 +76,19 @@ const Category = () => {
       <Table columns={columns} dataSource={dataSource} />
     </div>
   )
+}
+
+// Fetches data for the category and displays in the antd table
+const Category = () => {
+  const stateContext = useContext(StateContext)
+  const { loadingState } = stateContext
+
+  // Loading when state being fetched from geolocation
+  if (loadingState) {
+    return <Loader />
+  } else {
+    return <CategoryComponent stateContext={stateContext} />
+  }
 }
 
 export default Category

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -3,7 +3,7 @@ import "./Loader.scss"
 
 const Loader = () => {
   return (
-    <div className="loader fullScreen">
+    <div className="loader">
       <Space size="middle">
         <Spin size="large" />
       </Space>

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -1,0 +1,14 @@
+import { Spin, Space } from "antd"
+import "./Loader.scss"
+
+const Loader = () => {
+  return (
+    <div className="loader fullScreen">
+      <Space size="middle">
+        <Spin size="large" />
+      </Space>
+    </div>
+  )
+}
+
+export default Loader

--- a/src/components/Loader.scss
+++ b/src/components/Loader.scss
@@ -1,0 +1,9 @@
+.loader {
+  &.fullScreen {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/src/components/Loader.scss
+++ b/src/components/Loader.scss
@@ -1,9 +1,5 @@
 .loader {
-  &.fullScreen {
-    width: 100vw;
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/src/context/StateContext.js
+++ b/src/context/StateContext.js
@@ -2,8 +2,6 @@ import { createContext, useEffect, useState } from "react"
 import { geolocated } from "react-geolocated"
 // constant
 import { states } from "constant/states"
-// components
-import Loader from "components/Loader"
 
 export const StateContext = createContext()
 
@@ -92,7 +90,7 @@ export default function StateContextWrapper({ children }) {
           setLoadingState={setLoadingState}
         />
       )}
-      {loadingState ? <Loader /> : children}
+      {children}
     </StateContext.Provider>
   )
 }

--- a/src/context/StateContext.js
+++ b/src/context/StateContext.js
@@ -24,7 +24,6 @@ const GeoLocation = geolocated({
           response.json().then((location) => {
             const currentState = location?.principalSubdivision
             if (currentState && states.includes(currentState)) {
-              localStorage.setItem("state", currentState)
               setSelectedState(currentState)
             }
           })
@@ -40,12 +39,20 @@ const GeoLocation = geolocated({
 export default function StateContextWrapper({ children }) {
   const persistedState = localStorage.getItem("state")
   const [selectedState, setSelectedState] = useState(persistedState)
-  const contextValues = { selectedState, setSelectedState }
+  const contextValues = {
+    selectedState,
+    setSelectedState: (v) => {
+      localStorage.setItem("state", v)
+      setSelectedState(v)
+    },
+  }
 
   // TODO: Add location based on the browser location as the default state - if possible
   return (
     <StateContext.Provider value={contextValues}>
-      {!persistedState && <GeoLocation setSelectedState={setSelectedState} />}
+      {!persistedState && (
+        <GeoLocation setSelectedState={contextValues.setSelectedState} />
+      )}
       {children}
     </StateContext.Provider>
   )

--- a/src/context/StateContext.js
+++ b/src/context/StateContext.js
@@ -22,12 +22,10 @@ const GeoLocation = geolocated({
       ).then((response) => {
         if (response) {
           response.json().then((location) => {
-            if (
-              location &&
-              location.principalSubdivision &&
-              states.includes(location.principalSubdivision)
-            ) {
-              setSelectedState(location.principalSubdivision)
+            const currentState = location?.principalSubdivision
+            if (currentState && states.includes(currentState)) {
+              localStorage.setItem("state", currentState)
+              setSelectedState(currentState)
             }
           })
         }
@@ -40,11 +38,14 @@ const GeoLocation = geolocated({
 
 // Permission Provider
 export default function StateContextWrapper({ children }) {
-  const [selectedState, setSelectedState] = useState(undefined)
+  const persistedState = localStorage.getItem("state")
+  const [selectedState, setSelectedState] = useState(persistedState)
+  const contextValues = { selectedState, setSelectedState }
+
   // TODO: Add location based on the browser location as the default state - if possible
   return (
-    <StateContext.Provider value={{ selectedState, setSelectedState }}>
-      <GeoLocation setSelectedState={setSelectedState} />
+    <StateContext.Provider value={contextValues}>
+      {!persistedState && <GeoLocation setSelectedState={setSelectedState} />}
       {children}
     </StateContext.Provider>
   )


### PR DESCRIPTION
## Summary

- The user's current location or the state that the user picked from the dropdown, is now stored in the local storage so there are no subsequent requests made to the browser geo location or the api call (to get state info from lat / long)
- Added a loading screen for the first time the user enters the site 

## Flow 
First time user visits site, it shows the loading screen while verifying if their browser allows location and shows the location dialog
- If user selects **Block** - it stops loading screen immediately and shows information from all the states
- If user selects **Allow** - it stops the loading screen after making an api call and getting the relevant state info, which is stored in the local storage
- If user does not select anything - it times out and removes the loading screen (considers as blocked after 5 seconds) and the user can see all states info

When the user visits the site again, the state is just fetched from the local storage and populated in the dropdown. So no other calls are made. This is provided the location was previously fetched or the user had selected a state from the dropdown

## Improvement
- The loading screen can be moved inside the tables instead of blocking the entire screen