### PR TITLE
Feature/resources

### DIFF
--- a/src/components/Category.js
+++ b/src/components/Category.js
@@ -1,14 +1,16 @@
 // hooks
 import { useContext } from "react"
-import { useParams } from "react-router-dom"
+import { useHistory, useParams } from "react-router-dom"
 import { useList } from "react-firebase-hooks/database"
 // antd
-import { Table } from "antd"
+import { Result, Button, Table } from "antd"
 // constants
 import { db } from "constant/firebase"
-import { SPREADSHEET_KEY } from "constant/static"
+import { CATEGORIES, SPREADSHEET_KEY } from "constant/static"
 // context
 import { StateContext } from "context/StateContext"
+// helper
+import { toTitleCase } from "utils/caseHelper"
 // components
 import Loader from "components/Loader"
 
@@ -40,8 +42,7 @@ const COLUMNS = [
   },
 ]
 
-const CategoryComponent = ({ stateContext }) => {
-  let { category } = useParams()
+const CategoryComponent = ({ category, stateContext }) => {
   const { selectedState } = stateContext
 
   // fetch all by default
@@ -80,14 +81,32 @@ const CategoryComponent = ({ stateContext }) => {
 
 // Fetches data for the category and displays in the antd table
 const Category = () => {
+  const history = useHistory()
+  let { category } = useParams()
+
   const stateContext = useContext(StateContext)
   const { loadingState } = stateContext
 
-  // Loading when state being fetched from geolocation
+  // Only fetch category from firebase if it is in the approved list of CATEGORIES
+  if (!CATEGORIES.includes(toTitleCase(category))) {
+    return (
+      <Result
+        status="404"
+        title="404"
+        subTitle={`Requested category ${category} not found`}
+        extra={
+          <Button onClick={() => history.push("/")} type="primary">
+            Back Home
+          </Button>
+        }
+      />
+    )
+  }
   if (loadingState) {
+    // Loading when state being fetched from geolocation
     return <Loader />
   } else {
-    return <CategoryComponent stateContext={stateContext} />
+    return <CategoryComponent category={category} stateContext={stateContext} />
   }
 }
 

--- a/src/components/EmergencyInfo.js
+++ b/src/components/EmergencyInfo.js
@@ -1,109 +1,180 @@
+// hooks
+import { useContext } from "react"
+import { useList } from "react-firebase-hooks/database"
+// icons
 import { ReactComponent as PDFIcon } from "assets/icons/pdf.svg"
+// constant
+import { db } from "constant/firebase"
+import { SPREADSHEET_KEY } from "constant/static"
+// components
+import Loader from "components/Loader"
+// context
+import { StateContext } from "context/StateContext"
 
-const EmergencyInfo = () => (
-  <section className="content">
-    <div className="resources-wrapper">
-      <div className="emergency-resources resource">
-        <h3>Emergency Resources</h3>
-        <div className="resources-block">
-          <div className="label">24/7 Helpline:</div>
-          <div className="content">
-            <a href="tel:+911123978046">+91-11-23978046</a>
-            <a href="tel:1075">1075 (Toll Free)</a>
-          </div>
-        </div>
-        <div className="resources-block">
-          <div className="label">WhatsApp Helpdesk (Live Chat)</div>
-          <div className="content">
-            <a href="https://wa.me/919013151515">https://wa.me/919013151515</a>
-          </div>
-        </div>
-        <div className="resources-block">
-          <div className="label">Facebook Helpdesk: (Messenger Chat)</div>
-          <div className="content">
-            <a
-              href="https://www.messenger.com/t/MyGovIndia"
-              target="_blank"
-              rel="noreferrer"
-            >
-              https://www.messenger.com/t/MyGovIndia
-            </a>
-          </div>
-        </div>
-        <div className="resources-block">
-          <div className="label">Local Helplines:</div>
-          <div className="content">
-            <a
-              href="https://www.mohfw.gov.in/pdf/coronvavirushelplinenumber.pdf"
-              target="_blank"
-              rel="noreferrer"
-            >
-              States &amp; Union Territories Local Helplines
-            </a>
-          </div>
-        </div>
-      </div>
-      <div className="latest-updates resource">
-        <h3>Latest Updates</h3>
-        <div className="content">
-          <a
-            className="item"
-            href="https://static.mygov.in/rest/s3fs-public/mygov_161848046251307401.pdf"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <PDFIcon />
-            <span>Decision on CBSE Board Exams</span>
-          </a>
-          <a
-            className="item"
-            href="https://im.rediff.com/news/2021/apr/13break-the-chain.pdf"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <PDFIcon />
-            <span>Maharashtra: Break the Chain (14 Apr) - Official Order</span>
-          </a>
-        </div>
-      </div>
-      <div className="documents resource">
-        <h3>Helpful Guidelines &amp; Official Documents</h3>
-        <div className="content">
-          <a
-            className="item"
-            href="https://www.mohfw.gov.in/pdf/Algorithmforinternationalarrivals.pdf"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <PDFIcon />
-            <span>
-              Algorithm: Standard Operating Procedure for International Arrivals
-            </span>
-          </a>
-          <a
-            className="item"
-            href="https://www.mohfw.gov.in/pdf/Guidelinesforinternationalarrivals17022021.pdf"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <PDFIcon />
-            <span>Guidelines for International Arrivals</span>
-          </a>
-          <a
-            className="item"
-            href="https://www.mohfw.gov.in/pdf/FAQCoWINforcitizens.pdf"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <PDFIcon />
-            <span>
-              Frequently Asked Questions on Co-WIN (COVID-19 Vaccination)
-            </span>
-          </a>
-        </div>
+const titles = [
+  "24/7 Helpline",
+  "Facebook Helpdesk (Messenger Chat)",
+  "WhatsApp Helpdesk (Live Chat)",
+  "Local Help",
+  "Local Helplines",
+]
+
+const ResourceBlock = ({ title, resource }) => {
+  return (
+    <div className="resources-block">
+      <div className="label">{title}:</div>
+      <div className="content">
+        {resource &&
+          resource.length > 0 &&
+          resource.map((res, idx) => {
+            if (!res.Value) return null
+            if (res.Link)
+              return (
+                <a key={idx} href={res.Link} rel="noreferrer" target="_blank">
+                  {res.Value}
+                </a>
+              )
+            return <span key={idx}>{res.Value}</span>
+          })}
       </div>
     </div>
-  </section>
+  )
+}
+
+const LatestUpdates = () => {
+  return (
+    <div className="latest-updates resource">
+      <h3>Latest Updates</h3>
+      <div className="content">
+        <a
+          className="item"
+          href="https://static.mygov.in/rest/s3fs-public/mygov_161848046251307401.pdf"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <PDFIcon />
+          <span>Decision on CBSE Board Exams</span>
+        </a>
+        <a
+          className="item"
+          href="https://im.rediff.com/news/2021/apr/13break-the-chain.pdf"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <PDFIcon />
+          <span>Maharashtra: Break the Chain (14 Apr) - Official Order</span>
+        </a>
+      </div>
+    </div>
+  )
+}
+
+const Documents = () => (
+  <div className="documents resource">
+    <h3>Helpful Guidelines &amp; Official Documents</h3>
+    <div className="content">
+      <a
+        className="item"
+        href="https://www.mohfw.gov.in/pdf/Algorithmforinternationalarrivals.pdf"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <PDFIcon />
+        <span>
+          Algorithm: Standard Operating Procedure for International Arrivals
+        </span>
+      </a>
+      <a
+        className="item"
+        href="https://www.mohfw.gov.in/pdf/Guidelinesforinternationalarrivals17022021.pdf"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <PDFIcon />
+        <span>Guidelines for International Arrivals</span>
+      </a>
+      <a
+        className="item"
+        href="https://www.mohfw.gov.in/pdf/FAQCoWINforcitizens.pdf"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <PDFIcon />
+        <span>Frequently Asked Questions on Co-WIN (COVID-19 Vaccination)</span>
+      </a>
+    </div>
+  </div>
 )
+
+// Fetches from resources filters on state which it accepts as a prop
+const EmergencyResources = ({ heading, filterBy }) => {
+  const [snapshots, loading, error] = useList(
+    db
+      .ref(`${SPREADSHEET_KEY}/resources`)
+      .orderByChild("State")
+      .equalTo(filterBy)
+  )
+  const dataSource = snapshots.map((i) => i.val())
+
+  // Create object of arrays from titles
+  // {"24/7 Helpline": [Resource, Resource],
+  //  "Local Helpline": [Resource]
+  // }
+  const titleObj = {}
+  if (dataSource) {
+    for (const i of dataSource) {
+      if (titleObj[i.Title]) {
+        titleObj[i.Title] = [...titleObj[i.Title], i]
+      } else {
+        titleObj[i.Title] = [i]
+      }
+    }
+  }
+
+  if (loading) {
+    return <Loader />
+  }
+  if (error) {
+    return <p>An error occurred...</p>
+  }
+
+  if (dataSource.length > 0) {
+    return (
+      <div className="emergency-resources resource">
+        <h3>{heading}</h3>
+        {/* Looping through static titles so the order is maintained */}
+        {titles.map((title) => {
+          if (titleObj[title]) {
+            const resource = titleObj[title]
+            return (
+              <ResourceBlock key={title} title={title} resource={resource} />
+            )
+          }
+          return null
+        })}
+      </div>
+    )
+  }
+  return null
+}
+
+const EmergencyInfo = () => {
+  const { selectedState } = useContext(StateContext)
+  return (
+    <section className="content">
+      <div className="resources-wrapper">
+        <EmergencyResources heading="National Resources" filterBy="National" />
+        <LatestUpdates />
+        <Documents />
+        {selectedState && (
+          <EmergencyResources
+            heading={`Resources in ${selectedState}`}
+            filterBy={selectedState}
+          />
+        )}
+      </div>
+    </section>
+  )
+}
 
 export default EmergencyInfo

--- a/src/constant/static.js
+++ b/src/constant/static.js
@@ -1,5 +1,5 @@
 const SPREADSHEET_KEY = "11cAlFOEgfIyE0jmV_8X8_DqImCfxHyk7zo8wETFX9x4"
-const TAGS = [
+const CATEGORIES = [
   "Beds",
   "Oxygen Cylinders",
   "Remdesivir",
@@ -7,4 +7,4 @@ const TAGS = [
   "Ventilators",
 ]
 
-export { TAGS, SPREADSHEET_KEY }
+export { CATEGORIES, SPREADSHEET_KEY }

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -8,7 +8,7 @@ import { ReactComponent as SearchIcon } from "assets/icons/search.svg"
 import Category from "components/Category"
 import EmergencyInfo from "components/EmergencyInfo"
 // constants
-import { TAGS } from "constant/static"
+import { CATEGORIES } from "constant/static"
 // helper
 import { toKebabCase } from "utils/caseHelper"
 // styles
@@ -27,7 +27,7 @@ export default function Home() {
             suffix={<SearchIcon />}
           />
           <div className="tags">
-            {TAGS.map((i) => (
+            {CATEGORIES.map((i) => (
               <NavLink
                 key={i}
                 activeClassName="is-active"

--- a/src/pages/Home.scss
+++ b/src/pages/Home.scss
@@ -100,7 +100,8 @@
         }
 
         .emergency-resources {
-          grid-area: emergency;
+          // grid-area: emergency;
+          // TODO: Fix
 
           .resources-block {
             margin-bottom: 32px;

--- a/src/utils/caseHelper.js
+++ b/src/utils/caseHelper.js
@@ -1,3 +1,15 @@
 const toKebabCase = (i) => (!i ? "" : i.toLowerCase().split(" ").join("-"))
+const toTitleCase = (i) =>
+  !i
+    ? ""
+    : i
+        .toString()
+        .replace(/([a-z])([A-Z])/g, function (a, firstMatch, secondMatch) {
+          return firstMatch + " " + secondMatch
+        })
+        .toLowerCase()
+        .replace(/([ -_]|^)(.)/g, function (a, firstMatch, secondMatch) {
+          return (firstMatch ? " " : "") + secondMatch.toUpperCase()
+        })
 
-export { toKebabCase }
+export { toTitleCase, toKebabCase }


### PR DESCRIPTION
## Summary
Fetch resources from spreadsheet (resources sheet) and display on the home page.
Created a reusable component `EmergencyResources` which accepts a `heading` and `filterBy` prop.
This is used to fetch the national resources and the resources per state. The resources per state are only fetched if the state is selected in the header dropdown and exists in the state context.

## Pending
- **Styles** - I commented the grid style for emergency section since now there are 2 emergency sections and they were overlapping. This needs to be fixed / rearranged.
- **Internal Links** - For "Mumbai War Rooms" and other hard-coded pages, I have created an "Internal Link" field which we can use to route to internal pages. We can probably route pages at `/page/:id` and then fetch the id from the spreadsheet in a similar way.

## Aside
- Now shows 404 if requested category is not found. If user navigates to `/search/{category}`. It should show 404 if category is not in the static list of categories that are pre-defined. Prevents extra firebase request from being made.