### PR TITLE
Feature/internal-links

### DIFF
--- a/src/Site.js
+++ b/src/Site.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Switch, Route } from "react-router-dom"
 import Header from "./components/Header"
 import Footer from "./components/Footer"
 import Home from "./pages/Home"
+import InfoPage from "./pages/InfoPage"
 import "./Site.css"
 
 function Site() {
@@ -13,6 +14,7 @@ function Site() {
         <Switch>
           <Route path="/" component={Home} exact />
           <Route path="/search" component={Home} />
+          <Route path="/info/:page" component={InfoPage} />
           {/* <Route path="/contribute" component={Contribute} /> */}
         </Switch>
         <Footer />

--- a/src/components/EmergencyInfo.js
+++ b/src/components/EmergencyInfo.js
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom"
 // hooks
 import { useContext } from "react"
 import { useList } from "react-firebase-hooks/database"
@@ -28,6 +29,13 @@ const ResourceBlock = ({ title, resource }) => {
           resource.length > 0 &&
           resource.map((res, idx) => {
             if (!res.Value) return null
+            if (res.InternalLink) {
+              return (
+                <Link key={idx} to={`info/${res.InternalLink}`}>
+                  {res.Value}
+                </Link>
+              )
+            }
             if (res.Link)
               return (
                 <a key={idx} href={res.Link} rel="noreferrer" target="_blank">

--- a/src/constant/states.js
+++ b/src/constant/states.js
@@ -29,4 +29,17 @@ const states = [
   "West Bengal",
 ]
 
-export { states }
+const unionTerritories = [
+  "Andaman and Nicobar Islands",
+  "Chandigarh",
+  "Dadra and Nagar Haveli and Daman & Diu",
+  "Delhi",
+  "Jammu & Kashmir",
+  "Ladakh",
+  "Lakshadweep",
+  "Puducherry",
+]
+
+const all = [...states, ...unionTerritories]
+
+export { all as states }

--- a/src/pages/InfoPage.js
+++ b/src/pages/InfoPage.js
@@ -1,0 +1,101 @@
+import { useHistory, useParams } from "react-router-dom"
+import { useList } from "react-firebase-hooks/database"
+// pages
+// import WarRooms from "pages/WarRooms"
+// components
+import Loader from "components/Loader"
+// antd
+import { Result, Button, Table } from "antd"
+// constants
+import { db } from "constant/firebase"
+// styles
+import "./InfoPage.scss"
+import { SPREADSHEET_KEY } from "constant/static"
+
+const PAGE_LIST = {
+  "mumbai-war-rooms": {
+    heading: "Mumbai War Rooms",
+    // customComponent: (p) => <WarRooms {...p} />,
+    columns: [
+      {
+        title: "Ward",
+        dataIndex: "Ward",
+        key: "Ward",
+      },
+      {
+        title: "War Room Number",
+        dataIndex: "War Room Number",
+        key: "War Room Number",
+      },
+      {
+        title: "Areas",
+        dataIndex: "Areas",
+        key: "Areas",
+      },
+    ],
+  },
+}
+
+// Automatically fetches page param from spreadsheet
+// And renders information
+// -- can use custom components
+const InfoPageComponent = (props) => {
+  const { columns, customComponent, heading, page } = props
+  const [snapshots, loading, error] = useList(
+    db.ref(`${SPREADSHEET_KEY}/${page}`)
+  )
+  const dataSource = snapshots.map((i) => i.val())
+
+  if (loading) {
+    return <Loader />
+  }
+  if (error) {
+    return <p>An error occurred</p>
+  }
+
+  if (!dataSource) return <p>No records returned.</p>
+
+  // We can also use a custom component if required for something
+  if (customComponent) {
+    return customComponent({ data: dataSource, heading })
+  }
+
+  // Displays a table by default
+  return (
+    <>
+      {heading && <h3>{heading}</h3>}
+      <Table columns={columns} dataSource={dataSource} />
+    </>
+  )
+}
+
+// Returns 404 if page param is not in PAGE_LIST
+const InfoPage = () => {
+  const history = useHistory()
+  const { page } = useParams()
+  if (!PAGE_LIST[page]) {
+    return (
+      <section className="info-page">
+        <Result
+          status="404"
+          title="404"
+          subTitle={`Requested page ${page} not found`}
+          extra={
+            <Button onClick={() => history.push("/")} type="primary">
+              Back Home
+            </Button>
+          }
+        />
+      </section>
+    )
+  }
+
+  const info = PAGE_LIST[page]
+  return (
+    <section className="info-page">
+      <InfoPageComponent {...info} page={page} />
+    </section>
+  )
+}
+
+export default InfoPage

--- a/src/pages/InfoPage.scss
+++ b/src/pages/InfoPage.scss
@@ -1,0 +1,6 @@
+.info-page {
+    padding-top: 144px;
+    h3 {
+        text-align: center;
+    }
+}


### PR DESCRIPTION
Add `info/:page` route for internal links.

## Flow
- In the resources sheet in the spreadsheet, if a value is present in "InternalLink", this gets displayed on the frontend in a react router `<Link` component and gets routed to `info/{internalLinkValueFromSpreadsheet}`. Example `/info/mumbai-war-rooms`
- Routes on `info/:page` render `InfoPage` component, which check if the `:page` param is present in a static PAGE_LIST. 
- If **not present** - it shows 404 Not Found and prevents a firebase request
- If **present** - it first fetches the records from firebase `SPREADSHEET_KEY/:page`. 
- Then it renders either a custom component - OR - it shows a table with the columns specified in PAGE_LIST

## Things to Note
1. Value in the internal link cell on the **resources** spreadsheet should be present as a key on PAGE_LIST, otherwise the page won't show up
2. There must be a page in the spreadsheet with the same name as the internal link field
3. Columns must be specified if the data is to be shown in the default table format

## Structure
Static `PAGE_LIST ` has the structure 
```
{
   'page-name': {
        heading: "", // heading to display
        columns: [], // array of columns to show in table
        customComponent: CustomPage // component to show instead of the table
   }
  ...
}
```